### PR TITLE
Typo: Launcpad

### DIFF
--- a/index.php
+++ b/index.php
@@ -322,7 +322,7 @@
               <tr>
                 <td><b>Ubuntu:</b></td>
                 <td>
-                  <a href="<?php echo $ppaPre; ?>">Launcpad PPA (Pre-Release)</a>
+                  <a href="<?php echo $ppaPre; ?>">Launchpad PPA (Pre-Release)</a>
                 </td>
               </tr>
               <tr>

--- a/index.php
+++ b/index.php
@@ -270,7 +270,7 @@
             <tr>
               <td><b>Ubuntu:</b></td>
               <td>
-                <a href="<?php echo $ppaFull; ?>">Launcpad PPA</a>
+                <a href="<?php echo $ppaFull; ?>">Launchpad PPA</a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
There was a typo in the Ubuntu section of the Download and Setup section for both the stable and testing versions.